### PR TITLE
Remove 793 fields for UCSD only

### DIFF
--- a/xsl/PQ2MARC.xsl
+++ b/xsl/PQ2MARC.xsl
@@ -697,14 +697,6 @@
 			</marc:datafield>  
 		</xsl:for-each>
 
-		<marc:datafield tag="793" ind1="0" ind2=" ">
-			<marc:subfield code="a">UCSD online theses and dissertations.</marc:subfield>
-		</marc:datafield> 
-		<marc:datafield tag="793" ind1="0" ind2=" ">
-			<marc:subfield code="a">Open access resource; selected by the UC San Diego Library.</marc:subfield>
-			<marc:subfield code="p">eScholarship online dissertations.</marc:subfield>
-		</marc:datafield>
-
 		<xsl:for-each select="DISS_authorship/DISS_author">
 			<xsl:if test="@type!='primary'">
 				<xsl:variable name="surname" select="DISS_name/DISS_surname" />


### PR DESCRIPTION
Remove 793 fields from ETD service generated MARC records for UCSD, per request from HC.